### PR TITLE
fix: remove unsupported hero image reference from docs splash page

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -4,8 +4,6 @@ description: Use Claude Code with any OpenAI-compatible provider
 template: splash
 hero:
   tagline: Use Claude Code with any OpenAI-compatible provider
-  image:
-    file: /images/demo.png
   actions:
     - text: Get Started
       link: /claude-code-proxy/getting-started/


### PR DESCRIPTION
## Summary

- Remove the `hero.image.file` reference from `docs/index.mdx` that caused the Astro build to fail after #24 was merged
- Files in `docs/images/` are auto-mounted as public static assets and cannot be imported through Astro's image asset pipeline
- The splash page works well with just the tagline and action buttons

Closes #25

## Test plan

- [ ] CI checks pass (especially `GitHub Pages Deploy`)
- [ ] Post-merge: docs site builds successfully at https://f5xc-salesdemos.github.io/claude-code-proxy/

🤖 Generated with [Claude Code](https://claude.com/claude-code)