### PR TITLE
docs: align frontmatter and hero with ecosystem standard

### DIFF
--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -2,6 +2,7 @@
 title: Configuration Reference
 description: Environment variables, provider examples, and custom headers
 sidebar:
+  label: Configuration
   order: 2
 ---
 

--- a/docs/images/hero.svg
+++ b/docs/images/hero.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" width="40" height="40">
+  <style>
+    .stroke-primary { stroke: var(--color-N600, #0f1e57); }
+    .fill-primary { fill: var(--color-N600, #0f1e57); }
+    .stroke-brand { stroke: var(--color-brand, #e4002b); }
+    .fill-brand { fill: var(--color-brand, #e4002b); }
+    .fill-light { fill: var(--color-blue-light, #e5eaff); }
+    @media (prefers-color-scheme: dark) {
+      .stroke-primary { stroke: #e5eaff; }
+      .fill-primary { fill: #e5eaff; }
+      .fill-light { fill: #0e41aa; }
+    }
+  </style>
+  <!-- Central node -->
+  <circle cx="20" cy="20" r="6" class="fill-light stroke-primary" stroke-width="1.5" />
+  <circle cx="20" cy="20" r="2.5" class="fill-brand" />
+  <!-- Left arrow (incoming) -->
+  <line x1="3" y1="20" x2="12" y2="20" class="stroke-primary" stroke-width="1.5" stroke-linecap="round" />
+  <polyline points="9,17 12,20 9,23" class="stroke-primary" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none" />
+  <!-- Right arrow (outgoing) -->
+  <line x1="28" y1="20" x2="37" y2="20" class="stroke-primary" stroke-width="1.5" stroke-linecap="round" />
+  <polyline points="34,17 37,20 34,23" class="stroke-primary" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none" />
+  <!-- Top arrow (incoming) -->
+  <line x1="20" y1="3" x2="20" y2="12" class="stroke-primary" stroke-width="1.5" stroke-linecap="round" />
+  <polyline points="17,9 20,12 23,9" class="stroke-primary" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none" />
+  <!-- Bottom arrow (outgoing) -->
+  <line x1="20" y1="28" x2="20" y2="37" class="stroke-primary" stroke-width="1.5" stroke-linecap="round" />
+  <polyline points="17,34 20,37 23,34" class="stroke-primary" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none" />
+  <!-- Diagonal connector accents -->
+  <line x1="8" y1="8" x2="14" y2="14" class="stroke-brand" stroke-width="1" stroke-linecap="round" opacity="0.6" />
+  <line x1="26" y1="26" x2="32" y2="32" class="stroke-brand" stroke-width="1" stroke-linecap="round" opacity="0.6" />
+  <line x1="32" y1="8" x2="26" y2="14" class="stroke-brand" stroke-width="1" stroke-linecap="round" opacity="0.6" />
+  <line x1="8" y1="32" x2="14" y2="26" class="stroke-brand" stroke-width="1" stroke-linecap="round" opacity="0.6" />
+</svg>

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: Claude Code Proxy
-description: Use Claude Code with any OpenAI-compatible provider
-template: splash
 hero:
   tagline: Use Claude Code with any OpenAI-compatible provider
+  image:
+    html: '<img src="/claude-code-proxy/images/hero.svg" alt="Claude Code Proxy" />'
   actions:
     - text: Get Started
       link: /claude-code-proxy/getting-started/
@@ -15,6 +15,7 @@ hero:
       variant: minimal
 sidebar:
   hidden: true
+  order: 0
 ---
 
 import { Card, CardGrid } from "@astrojs/starlight/components";


### PR DESCRIPTION
## Summary

- Remove `template: splash` and `description:` from `docs/index.mdx` (not used in ecosystem splash pages)
- Add `hero.image.html` with `<img>` tag pointing to new `hero.svg`
- Add `sidebar.order: 0` to `docs/index.mdx`
- Add `sidebar.label: Configuration` to `docs/configuration.mdx` for shorter nav display
- Create `docs/images/hero.svg` with ecosystem CSS custom properties (`--color-N600`, `--color-brand`, `--color-blue-light`) for dark/light mode

## Test plan

- [x] `hero.svg` exists at `docs/images/hero.svg`
- [x] No `template:` field in `index.mdx` (removed)
- [x] `hero.image.html` references `hero.svg`
- [x] `sidebar.order: 0` present on index page
- [x] `sidebar.label: Configuration` present on configuration page
- [x] `ruff check` and `ruff format --check` pass
- [x] All 70 tests pass
- [ ] GitHub Pages deploy succeeds after merge

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)