### PR TITLE
fix: add missing frontmatter to web search spec doc

### DIFF
--- a/docs/specifications/index.mdx
+++ b/docs/specifications/index.mdx
@@ -1,0 +1,9 @@
+---
+title: Specifications
+description: Reference specifications for proxy features and protocol compliance
+sidebar:
+  order: 6
+---
+
+Technical specifications documenting the protocols and formats
+implemented by the proxy.

--- a/docs/specifications/web-search-tool.md
+++ b/docs/specifications/web-search-tool.md
@@ -1,4 +1,10 @@
-# Anthropic Web Search Tool Specification
+---
+title: Web Search Tool Specification
+description: Anthropic server_tool_use / web_search_tool_result content block specification
+sidebar:
+  label: Web Search Spec
+  order: 1
+---
 
 > Reverse-engineered from the Anthropic API documentation,
 > Python SDK (`anthropic-sdk-python`) type definitions,


### PR DESCRIPTION
## Summary

- Add YAML frontmatter (title, description, sidebar) to `docs/specifications/web-search-tool.md` which was missing since PR #46
- Add `docs/specifications/index.mdx` section index page

## Problem

The Astro/Starlight docs build has been failing on every merge to `main` since PR #46 with:
```
[InvalidContentEntryDataError] docs → specifications/web-search-tool data does not match collection schema.
```

## Test plan

- [ ] CI linting passes
- [ ] GitHub Pages Deploy workflow succeeds (has been failing since PR #46)

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)