### PR TITLE
fix: restore upstream fork LICENSE copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Robin Mordasiewicz
+Copyright (c) 2024 fuergaosi233
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary

- Restore the LICENSE copyright line to match the upstream fork ([fuergaosi233/claude-code-proxy](https://github.com/fuergaosi233/claude-code-proxy))

## What changed

```diff
- Copyright (c) 2025 Robin Mordasiewicz
+ Copyright (c) 2024 fuergaosi233
```

## Why

The ecosystem governance template sync (PR #12) replaced the upstream author's copyright notice with our own. As a fork, we are required by the MIT License to preserve the original copyright. This PR restores it to match the upstream verbatim.

## Verification

The restored LICENSE matches the upstream file at [`7ea4177`](https://github.com/fuergaosi233/claude-code-proxy/commit/7ea4177a54a5ff7969a5f8ec76d9f80f2e0409e5) byte-for-byte.

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)